### PR TITLE
Boj 14938

### DIFF
--- a/최단경로/BOJ_14938.js
+++ b/최단경로/BOJ_14938.js
@@ -1,0 +1,53 @@
+const input = require('fs').readFileSync('test.txt').toString().trim().split('\n')
+const [n, m, r] = input[0].split(' ').map(Number)
+const itemsPerVertex = [0].concat(input[1].split(' ').map(Number))
+const edges = input.slice(2, m + 2).map((s) => s.split(' ').map(Number))
+
+const floydWarshall = (n, edges) => {
+  //create graph
+  const adjMatrix = new Map()
+
+  for (let i = 1; i < n + 1; i++) {
+    adjMatrix.set(i, new Map())
+    for (let j = 1; j < n + 1; j++) {
+      adjMatrix.get(i).set(j, Infinity)
+    }
+  }
+
+  for (const [v1, v2, weight] of edges) {
+    const newValue = Math.min(adjMatrix.get(v1).get(v2), weight)
+    adjMatrix.get(v1).set(v2, newValue)
+    adjMatrix.get(v2).set(v1, newValue)
+  }
+
+  for (let i = 1; i < n + 1; i++) {
+    adjMatrix.get(i).set(i, 0)
+  }
+
+  //O(V^3) traverse
+  for (let m = 1; m < n + 1; m++) {
+    for (let s = 1; s < n + 1; s++) {
+      for (let e = 1; e < n + 1; e++) {
+        if (adjMatrix.get(s).get(e) > adjMatrix.get(s).get(m) + adjMatrix.get(m).get(e)) {
+          adjMatrix.get(s).set(e, adjMatrix.get(s).get(m) + adjMatrix.get(m).get(e))
+        }
+      }
+    }
+  }
+  return adjMatrix
+}
+
+const solution = () => {
+  const adjMatrix = floydWarshall(n, edges)
+  let answer = 0
+  for (let i = 1; i < n + 1; i++) {
+    let tempSum = 0
+    for (const [j, dist] of adjMatrix.get(i).entries()) {
+      tempSum += dist <= r ? itemsPerVertex[j] : 0
+    }
+    answer = Math.max(answer, tempSum)
+  }
+  return answer
+}
+
+console.log(solution())

--- a/최단경로/BOJ_14938.js
+++ b/최단경로/BOJ_14938.js
@@ -1,35 +1,27 @@
 const input = require('fs').readFileSync('test.txt').toString().trim().split('\n')
-const [n, m, r] = input[0].split(' ').map(Number)
+const [N, M, R] = input[0].split(' ').map(Number)
 const itemsPerVertex = [0].concat(input[1].split(' ').map(Number))
-const edges = input.slice(2, m + 2).map((s) => s.split(' ').map(Number))
+const edges = input.slice(2, R + 2).map((s) => s.split(' ').map(Number))
 
-const floydWarshall = (n, edges) => {
+const floydWarshall = (N, edges) => {
   //create graph
-  const adjMatrix = new Map()
-
-  for (let i = 1; i < n + 1; i++) {
-    adjMatrix.set(i, new Map())
-    for (let j = 1; j < n + 1; j++) {
-      adjMatrix.get(i).set(j, Infinity)
-    }
-  }
+  const adjMatrix = Array.from({ length: N + 1 }, (_, i) =>
+    Array.from({ length: N + 1 }, (_, j) => (i === j ? 0 : Infinity)),
+  )
 
   for (const [v1, v2, weight] of edges) {
-    const newValue = Math.min(adjMatrix.get(v1).get(v2), weight)
-    adjMatrix.get(v1).set(v2, newValue)
-    adjMatrix.get(v2).set(v1, newValue)
-  }
-
-  for (let i = 1; i < n + 1; i++) {
-    adjMatrix.get(i).set(i, 0)
+    const smaller = Math.min(adjMatrix[v1][v2], weight)
+    adjMatrix[v1][v2] = smaller
+    adjMatrix[v2][v1] = smaller
   }
 
   //O(V^3) traverse
-  for (let m = 1; m < n + 1; m++) {
-    for (let s = 1; s < n + 1; s++) {
-      for (let e = 1; e < n + 1; e++) {
-        if (adjMatrix.get(s).get(e) > adjMatrix.get(s).get(m) + adjMatrix.get(m).get(e)) {
-          adjMatrix.get(s).set(e, adjMatrix.get(s).get(m) + adjMatrix.get(m).get(e))
+  for (let m = 1; m < N + 1; m++) {
+    for (let s = 1; s < N + 1; s++) {
+      for (let e = 1; e < N + 1; e++) {
+        if (adjMatrix[s][e] > adjMatrix[s][m] + adjMatrix[m][e]) {
+          adjMatrix[s][e] = adjMatrix[s][m] + adjMatrix[m][e]
+          adjMatrix[e][s] = adjMatrix[s][m] + adjMatrix[m][e]
         }
       }
     }
@@ -38,13 +30,13 @@ const floydWarshall = (n, edges) => {
 }
 
 const solution = () => {
-  const adjMatrix = floydWarshall(n, edges)
+  const adjMatrix = floydWarshall(N, edges)
   let answer = 0
-  for (let i = 1; i < n + 1; i++) {
+  for (let i = 1; i < N + 1; i++) {
     let tempSum = 0
-    for (const [j, dist] of adjMatrix.get(i).entries()) {
-      tempSum += dist <= r ? itemsPerVertex[j] : 0
-    }
+    adjMatrix[i].forEach((dist, vertex) => {
+      tempSum += dist <= M ? itemsPerVertex[vertex] : 0
+    })
     answer = Math.max(answer, tempSum)
   }
   return answer


### PR DESCRIPTION
# 문제: [서강 그라운드](https://www.acmicpc.net/problem/14938)
![image](https://user-images.githubusercontent.com/44149596/158752889-98c63b2d-bf21-453a-91be-01e7e8d8cbfd.png)
## 문제풀이 접근법
- 플로이드-워셜 알고리즘
- 모든 정점으로부터 모든 정점으로의 최단 거리를 한 번에 알 수 있는 알고리즘입니다.
- 다익스트라 알고리즘에서 사용했던 인접 리스트가 아닌 인접 매트릭스를 사용하였습니다.
- 다익스트라와 다르게 음의 간선에서도 사용이 가능합니다.
- 두 정점 s, e 사이의 최단 거리를 알기 위해 s와 e의 중간에 있는 m 정점을 활용하는 알고리즘입니다.
  - 만약 s,e사이의 거리 d[s][e]가 d[s][m] + d[m][e] 보다 크다면 우회 경로가 더 작은 거리가 되므로 갱신해주는 식으로 알고리즘을 전개합니다.
## 구현 시 어려웠던 점과 깨달음
- 주어진 변수명을 착각하여 사용했습니다. r은 간선의 개수인데, r을 수색범위로 착각하고 로직을 진행하여 여러번 '틀렸습니다'. 문제를 꼼꼼히 읽는 습관이 필요합니다.


