### PR TITLE
Add: 2022-03-21 별찍기-11 문제해결

### DIFF
--- a/재귀/BOJ_2448.js
+++ b/재귀/BOJ_2448.js
@@ -1,0 +1,22 @@
+const N = require('fs').readFileSync('/dev/stdin').toString().trim() * 1
+const map = Array.from({ length: N }, () => Array.from({ length: 2 * N }, () => ' '))
+const baseFractal = ['  *   ', ' * *  ', '***** ']
+
+const makeFractal = (row, col, height) => {
+  if (height === 3) {
+    //base case
+    for (let i = 0; i < 3; i++) {
+      for (let j = 0; j < 6; j++) {
+        map[row + i][col + j] = baseFractal[i][j]
+      }
+    }
+    return
+  }
+  makeFractal(row, col + 0.5 * height, 0.5 * height)
+  makeFractal(row + 0.5 * height, col, 0.5 * height)
+  makeFractal(row + 0.5 * height, col + height, 0.5 * height)
+}
+makeFractal(0, 0, N)
+
+const result = map.reduce((prev, current) => prev + current.join('') + '\n', '')
+console.log(result)


### PR DESCRIPTION
# 문제: [별찍기-11](https://www.acmicpc.net/problem/2448)
## 문제풀이 접근법
- 좌표로 접근했습니다.
- 프랙탈이 크기가 동일한 세 가지 하위 프랙탈로 이루어져 있음을 파악하였습니다.
- 프랙탈이 시작하는 좌측 상단의 좌표와 프랙탈의 크기를 함수의 인자로 넘겨주어 재귀적으로 호출하여 문제를 해결했습니다. 
## 구현 시 어려웠던 점과 깨달음
- 분할정복을 해야겠다고는 생각했지만, 구체적으로 어떻게 분할 정복을 해야할지 몰라 많은 시간을 고민했습니다.
- 좌표를 이용하지 않고도 풀이를 진행할 수 있을 것 같았는데, 뭔가 아쉽네요. 현석님의 풀이는 좌표를 이용하지 않았는데다가 시간도 빨라서 한참을 감탄하며 들여다 보았습니다.

