### PR TITLE
Add: 2022-03-30 강의실 배정 1차 문제풀이 (시간초과)

### DIFF
--- a/우선순위큐/BOJ_11000.js
+++ b/우선순위큐/BOJ_11000.js
@@ -1,0 +1,37 @@
+const [[N], ...arr] = require('fs')
+  .readFileSync(__dirname + '/test.txt')
+  .toString()
+  .trim()
+  .split('\n')
+  .map((s) => s.split(' ').map(Number))
+
+const sortArr = (arr, mapper) => {
+  const data = []
+  arr.forEach((row) => {
+    data.push([...row])
+  })
+  data.sort(mapper)
+  return data
+}
+
+let startedIndex = 0
+let endedIndex = 0
+
+const startLectures = sortArr(arr, (a, b) => a[0] - b[0])
+const endLectures = sortArr(arr, (a, b) => a[1] - b[1])
+
+let max = 0
+let currentClassrooms = 0
+for (let i = 0; i < endLectures[endLectures.length - 1][1]; i++) {
+  if (startedIndex < N && startLectures[startedIndex][0] === i) {
+    currentClassrooms++
+    startedIndex++
+  }
+  if (endedIndex < N && endLectures[endedIndex][1] === i) {
+    currentClassrooms--
+    endedIndex++
+  }
+  max = Math.max(currentClassrooms, max)
+}
+
+console.log(max)

--- a/우선순위큐/BOJ_11000.js
+++ b/우선순위큐/BOJ_11000.js
@@ -5,33 +5,69 @@ const [[N], ...arr] = require('fs')
   .split('\n')
   .map((s) => s.split(' ').map(Number))
 
-const sortArr = (arr, mapper) => {
-  const data = []
-  arr.forEach((row) => {
-    data.push([...row])
-  })
-  data.sort(mapper)
-  return data
+class MinHeap {
+  constructor() {
+    this.heap = []
+  }
+  insert(value) {
+    this.heap.push(value)
+    this.upheap()
+  }
+  upheap(childIndex = this.heap.length - 1) {
+    while (Math.floor((childIndex - 1) / 2) >= 0) {
+      const parentIndex = Math.floor((childIndex - 1) / 2)
+      if (this.heap[parentIndex] < this.heap[childIndex]) break
+      const temp = this.heap[parentIndex]
+      this.heap[parentIndex] = this.heap[childIndex]
+      this.heap[childIndex] = temp
+      childIndex = parentIndex
+    }
+  }
+  pop() {
+    if (this.heap.length === 0) return null
+    const root = this.heap[0]
+    this.heap[0] = this.heap[this.heap.length - 1]
+    this.heap.pop()
+    if (this.heap.length === 1) {
+      return root
+    }
+    this.downheap()
+  }
+  downheap(parentIndex = 0) {
+    while (2 * parentIndex + 1 < this.heap.length) {
+      let childIndex = 2 * parentIndex + 1
+      if (childIndex + 1 < this.heap.length && this.heap[childIndex] > this.heap[childIndex + 1])
+        childIndex++
+      if (this.heap[parentIndex] < this.heap[childIndex]) break
+      const temp = this.heap[parentIndex]
+      this.heap[parentIndex] = this.heap[childIndex]
+      this.heap[childIndex] = temp
+      parentIndex = childIndex
+    }
+  }
+  top() {
+    return this.heap[0]
+  }
+  size() {
+    return this.heap.length
+  }
 }
 
-let startedIndex = 0
-let endedIndex = 0
+const lectures = arr.sort((a, b) => a[0] - b[0])
 
-const startLectures = sortArr(arr, (a, b) => a[0] - b[0])
-const endLectures = sortArr(arr, (a, b) => a[1] - b[1])
-
-let max = 0
-let currentClassrooms = 0
-for (let i = 0; i < endLectures[endLectures.length - 1][1]; i++) {
-  if (startedIndex < N && startLectures[startedIndex][0] === i) {
-    currentClassrooms++
-    startedIndex++
+let maxClassCount = 0
+let classCount = 1
+const minHeap = new MinHeap()
+minHeap.insert(lectures[0][1])
+for (let i = 1; i < lectures.length; i++) {
+  const [startTime, endTime] = lectures[i]
+  while (startTime >= minHeap.top()) {
+    minHeap.pop()
+    classCount--
   }
-  if (endedIndex < N && endLectures[endedIndex][1] === i) {
-    currentClassrooms--
-    endedIndex++
-  }
-  max = Math.max(currentClassrooms, max)
+  minHeap.insert(endTime)
+  classCount++
+  maxClassCount = Math.max(maxClassCount, classCount)
 }
 
-console.log(max)
+console.log(maxClassCount)


### PR DESCRIPTION
# 문제: [강의실 배정](https://www.acmicpc.net/problem/11000)
## 문제풀이 접근법
![image](https://user-images.githubusercontent.com/44149596/160783179-939ec78a-b3d0-4129-a1d3-78a109bbc275.png)

### 1차 문제풀이의 잘못된 접근 (틀렸습니다)
- 정렬을 이용하여 접근했습니다. 
- 사용가능한 최대의 강의실의 수는, 특정시간대에 동시에 유지되고 있는 강의의 수로 생각했습니다.
- 가령 t 시간에 사용가능한 최소의 강의실의 수는 t-1시간까지 유지되고 있던 강의실의 수 + t시간에 새로이 시작된 강의의 수 - t시간에 끝난 강의의 수 입니다. 
- 그래서 시작시간 기준으로 오름차순 정렬한 배열과, 종료시간 기준으로 오름차순 정렬한 배열 두 가지를 가지고 접근을 했으니, 시간초과에 걸렸습니다.

### 1차 문제풀이의 문제저
1차 문제풀이는 한 번에 하나씩의 강의만 추가하고 삭제할 수 있습니다. 이 점은, 시작 시간은 다르지만 강의 종료시간이 같은 복수의 강의들이 입력으로 주어지는 경우를 처리할 수 없었습니다.

### 옳은 접근법
현재 강의실을 점유하며 진행되고 있는 강의들의 끝나는 시간을 저장할 배열 `arr` 을 하나 만들어야겠다는 생각을 했습니다. 

그리고 입력된 강의를 시작시간순으로 오름차순 정렬을 한 후, 시작시간이 이른 강의부터 강의실을 배열에 추가하기로 했습니다. 

`arr`에 담겨있는 강의들 중, 현재 강의실을 배정하려는 강의의 시작시간(`startTime`)보다  이른 시간에 끝나는 강의들은 모두 제거되어야 합니다. 

단순한 배열에서 몇 개가 될 지 모를 강의들을 제거하려고 n번만큼을 매번 순회하는 것은 굉장히 비효율적인 일입니다. 그렇기때문에 강의들이 끝나는 시간을 저장하는 배열 `arr`를 단순 배열이 아닌 우선순위 큐로 재작성하였습니다. 

이제부터는 강의들이 끝나는 시간들이 저장되어 있는 큐를 `minHeap` 이라 하겠습니다.

최소 힙을 사용할 시의 장점은 O(1)시간에 최소값을 바로 찾을 수 있으며, O(logn)만큼의 힙의 재정렬 시간이 걸리기 때문에 시간 복잡도가 낮다는 것입니다.

## 구현 시 어려웠던 점과 깨달음
- 정렬과 우선순위 큐를 사용해야 하는 경우를 분간할 줄 알아야 합니다. 큐로의 잦은 입출력이 있고, 최소값과 최대값이 자주 변한다면 우선순위 큐를 사용해야하고, 그렇지 않다면 정렬을 사용해도 무방한 듯 합니다.

