### PR TITLE
Add: 추석 트래픽 1차 문제풀이(틀렸습니다)

### DIFF
--- a/구현/PG_1차_추석트래픽.js
+++ b/구현/PG_1차_추석트래픽.js
@@ -1,8 +1,7 @@
 function solution(lines) {
   let answer = 0
   let counter = 0
-  const startLogs = []
-  const endLogs = []
+  const allTimes = []
   const logs = []
   //millisecond로 변환 후 정렬
   lines.forEach((line) => {
@@ -10,49 +9,29 @@ function solution(lines) {
     const [hour, minute, second] = endTime.split(':').map(Number)
     const milliEndTime = (hour * 3600 + minute * 60 + second) * 1000
     const milliDuration = duration.slice(0, duration.length - 1) * 1000
-    const millliStartTime = milliEndTime - milliDuration + 1
-    startLogs.push(millliStartTime)
-    endLogs.push(milliEndTime)
+    const millliStartTime = milliEndTime - (milliDuration - 1)
+    allTimes.push(millliStartTime)
+    allTimes.push(milliEndTime)
     logs.push({ start: millliStartTime, end: milliEndTime })
   })
-  startLogs.sort((a, b) => a - b)
-  endLogs.sort((a, b) => a - b)
+  allTimes.sort((a, b) => a - b)
   logs.sort((a, b) => a.start - b.start)
-  //시작시간과 종료시간 기준으로 탐색 시작
-  for (let i = 0; i < startLogs.length; i++) {
-    //시작시간 기준 이후 1초 탐색
-    const leftWindow = startLogs[i]
-    const rightWindow = leftWindow + 1000 - 1
-    for (let j = 0; j < startLogs.length; j++) {
+  //시작시간과 종료시간 기준으로 탐색 시작 <- 처리 작업의 개수가 변하는 경우는 시작시간과 종료시간밖에 없으니
+  for (let i = 0; i < allTimes.length; i++) {
+    const leftWindow = allTimes[i]
+    const rightWindow = leftWindow + 999
+    for (let j = 0; j < logs.length; j++) {
       const { start, end } = logs[j]
-      if (start > rightWindow) break
       if (
         (start >= leftWindow && start <= rightWindow) ||
-        (end >= leftWindow && end <= rightWindow)
-      )
+        (end >= leftWindow && end <= rightWindow) ||
+        (start <= leftWindow && rightWindow <= end)
+      ) {
         counter++
-    }
-    answer = Math.max(counter, answer)
-    counter = 0
-  }
-  for (let i = 0; i < endLogs.length; i++) {
-    //종료시간 기준 이후 1초 탐색
-    const leftWindow = endLogs[i]
-    const rightWindow = leftWindow + 1000 - 1
-    for (let j = 0; j < endLogs.length; j++) {
-      const { start, end } = logs[j]
-      console.log('left, right', leftWindow, rightWindow, 'start,end', start, end)
-      if (start > rightWindow) break
-      if (
-        (start >= leftWindow && start <= rightWindow) ||
-        (end >= leftWindow && end <= rightWindow)
-      )
-        counter++
+      }
     }
     answer = Math.max(counter, answer)
     counter = 0
   }
   return answer
 }
-
-console.log(solution(['2016-09-15 01:00:04.002 2.0s', '2016-09-15 01:00:07.000 2s']))

--- a/구현/PG_1차_추석트래픽.js
+++ b/구현/PG_1차_추석트래픽.js
@@ -1,0 +1,62 @@
+function solution(lines) {
+  let answer = 0
+  let counter = 0
+  const startLogs = []
+  const endLogs = []
+  const logs = []
+  lines.forEach((line) => {
+    const [_, endTime, duration] = line.split(' ')
+    const [hour, minute, second] = endTime.split(':').map(Number)
+    const milliEndTime = (hour * 3600 + minute * 60 + second) * 1000
+    const milliDuration = duration.slice(0, duration.length - 1) * 1000
+    const millliStartTime = milliEndTime - milliDuration + 1
+    startLogs.push(millliStartTime)
+    endLogs.push(milliEndTime)
+    logs.push({ start: millliStartTime, end: milliEndTime })
+  })
+  startLogs.sort((a, b) => a - b)
+  endLogs.sort((a, b) => a - b)
+  logs.sort((a, b) => a.start - b.start)
+  for (let i = 0; i < startLogs.length; i++) {
+    //시작시간 기준 이후 1초 탐색
+    const startT = startLogs[i]
+    const endT = startT + 1000 - 1
+    for (let j = 0; j < startLogs.length; j++) {
+      const { start, end } = logs[j]
+      if (start > endT) break
+      if ((start >= startT && start <= endT) || (end >= startT && end <= endT)) counter++
+    }
+    answer = Math.max(counter, answer)
+    counter = 0
+  }
+  for (let i = 0; i < endLogs.length; i++) {
+    //종료시간 기준 이후 1초 탐색
+    const startT = endLogs[i]
+    const endT = startT + 1000 - 1
+    for (let j = 0; j < endLogs.length; j++) {
+      const { start, end } = logs[j]
+      if (start > endT) break
+      if ((start >= startT && start <= endT) || (end >= startT && end <= endT)) counter++
+    }
+    answer = Math.max(counter, answer)
+    counter = 0
+  }
+  return answer
+}
+
+console.log(solution(['2016-09-15 01:00:04.001 2.0s', '2016-09-15 01:00:07.000 2s']))
+
+console.log(
+  solution([
+    '2016-09-15 20:59:57.421 0.351s',
+    '2016-09-15 20:59:58.233 1.181s',
+    '2016-09-15 20:59:58.299 0.8s',
+    '2016-09-15 20:59:58.688 1.041s',
+    '2016-09-15 20:59:59.591 1.412s',
+    '2016-09-15 21:00:00.464 1.466s',
+    '2016-09-15 21:00:00.741 1.581s',
+    '2016-09-15 21:00:00.748 2.31s',
+    '2016-09-15 21:00:00.966 0.381s',
+    '2016-09-15 21:00:02.066 2.62s',
+  ]),
+)

--- a/구현/PG_1차_추석트래픽.js
+++ b/구현/PG_1차_추석트래픽.js
@@ -4,6 +4,7 @@ function solution(lines) {
   const startLogs = []
   const endLogs = []
   const logs = []
+  //millisecond로 변환 후 정렬
   lines.forEach((line) => {
     const [_, endTime, duration] = line.split(' ')
     const [hour, minute, second] = endTime.split(':').map(Number)
@@ -17,26 +18,36 @@ function solution(lines) {
   startLogs.sort((a, b) => a - b)
   endLogs.sort((a, b) => a - b)
   logs.sort((a, b) => a.start - b.start)
+  //시작시간과 종료시간 기준으로 탐색 시작
   for (let i = 0; i < startLogs.length; i++) {
     //시작시간 기준 이후 1초 탐색
-    const startT = startLogs[i]
-    const endT = startT + 1000 - 1
+    const leftWindow = startLogs[i]
+    const rightWindow = leftWindow + 1000 - 1
     for (let j = 0; j < startLogs.length; j++) {
       const { start, end } = logs[j]
-      if (start > endT) break
-      if ((start >= startT && start <= endT) || (end >= startT && end <= endT)) counter++
+      if (start > rightWindow) break
+      if (
+        (start >= leftWindow && start <= rightWindow) ||
+        (end >= leftWindow && end <= rightWindow)
+      )
+        counter++
     }
     answer = Math.max(counter, answer)
     counter = 0
   }
   for (let i = 0; i < endLogs.length; i++) {
     //종료시간 기준 이후 1초 탐색
-    const startT = endLogs[i]
-    const endT = startT + 1000 - 1
+    const leftWindow = endLogs[i]
+    const rightWindow = leftWindow + 1000 - 1
     for (let j = 0; j < endLogs.length; j++) {
       const { start, end } = logs[j]
-      if (start > endT) break
-      if ((start >= startT && start <= endT) || (end >= startT && end <= endT)) counter++
+      console.log('left, right', leftWindow, rightWindow, 'start,end', start, end)
+      if (start > rightWindow) break
+      if (
+        (start >= leftWindow && start <= rightWindow) ||
+        (end >= leftWindow && end <= rightWindow)
+      )
+        counter++
     }
     answer = Math.max(counter, answer)
     counter = 0
@@ -44,19 +55,4 @@ function solution(lines) {
   return answer
 }
 
-console.log(solution(['2016-09-15 01:00:04.001 2.0s', '2016-09-15 01:00:07.000 2s']))
-
-console.log(
-  solution([
-    '2016-09-15 20:59:57.421 0.351s',
-    '2016-09-15 20:59:58.233 1.181s',
-    '2016-09-15 20:59:58.299 0.8s',
-    '2016-09-15 20:59:58.688 1.041s',
-    '2016-09-15 20:59:59.591 1.412s',
-    '2016-09-15 21:00:00.464 1.466s',
-    '2016-09-15 21:00:00.741 1.581s',
-    '2016-09-15 21:00:00.748 2.31s',
-    '2016-09-15 21:00:00.966 0.381s',
-    '2016-09-15 21:00:02.066 2.62s',
-  ]),
-)
+console.log(solution(['2016-09-15 01:00:04.002 2.0s', '2016-09-15 01:00:07.000 2s']))


### PR DESCRIPTION
# 문제: [추석 트래픽](https://www.acmicpc.net/problem/[문제번호](https://programmers.co.kr/learn/courses/30/lessons/17676?language=javascript))
## 문제풀이 접근법
- 정렬, 슬라이딩 윈도우, 케이스 분류
## 구현 시 어려웠던 점과 깨달음
- 1차 문제풀이 결과 테스트케이스 2,3, 18이 실패했는데, 이유를 잘 모르겠습니다.
## 문제 해결!
- 문제 해결했습니다. 전반적인 접근법은 옳았습니다. 시작시간과 끝 시간만을 기준으로 이후 1초(처음과 끝 시간을 포함하기 때문에 끝 시간은= 시작 시간+ 999ms)의 범위에 걸쳐있는 로그를 세면 되는 문제가 맞았습니다.
- 다만 계속 테스트케이스 2,3,18에서 계속 틀렸던 이유는 **"걸쳐있다"** 라는 것에 대한 케이스 분류를 제대로 하지 못해서였습니다. 코드의 라인 25~28을 보시면 조건이 세 개인 것을 확인할 수 있습니다. 
  - 첫 번째 조건은 해당 범위 사이에 로그의 시작점이 위치해 있는 경우입니다.
  - 두 번째 조건은 해당 범위 사이에 로그의 끝점이 위치해 있는 경우입니다.
  - 세 번째 조건을 누락하여 테스트케이스 2,3, 18 을 통과하지 못했습니다. 세 번째 조건은 로그의 시작 시간과 끝나는 시간이 해당 범위보다 넓을 경우입니다. 
  ![image](https://user-images.githubusercontent.com/44149596/163798340-560a4337-2128-426e-88a5-f2e2d33509af.png)

  - 위 그림의 (3)번 구간에서 처리 중인 로그는 두 개입니다. 맨 마지막 로그는 시작점과 끝점이 범위보다 넓은데, 이 경우를 처리하는 조건을 저는 생각하지 못하고 있었습니다. 이 조건을 추가하니 모든 테스트 케이스를 통과했습니다.
