### PR TITLE
Add: 2022-04-19 자물쇠와 열쇠 문제해결

### DIFF
--- a/완전탐색/PG_자물쇠와 열쇠.js
+++ b/완전탐색/PG_자물쇠와 열쇠.js
@@ -1,0 +1,92 @@
+const rotateKey = (key) => {
+  const M = key.length
+  const newKey = Array.from({ length: M }, () => Array.from({ length: M }, () => 0))
+  for (let i = M - 1; i >= 0; i--) {
+    for (let j = 0; j < M; j++) {
+      newKey[j][M - 1 - i] = key[i][j]
+    }
+  }
+  return newKey
+}
+
+const copyAggregationGraph = (originalAggregationGraph) => {
+  const size = originalAggregationGraph.length
+  const copied = Array.from({ length: size }, () => Array.from({ length: size }, () => 0))
+  for (let i = 0; i < size; i++) {
+    for (let j = 0; j < size; j++) {
+      copied[i][j] = originalAggregationGraph[i][j]
+    }
+  }
+  return copied
+}
+
+function solution(key, lock) {
+  let answer = false
+  const M = key.length
+  const N = lock.length
+  const arregationSize = N + 2 * (M - 1)
+  const aggregationGraph = Array.from({ length: arregationSize }, () =>
+    Array.from({ length: arregationSize }, () => 0),
+  )
+  //맨 중앙에 lock을 복사해 넣기
+  for (let i = M - 1; i < N + M - 1; i++) {
+    for (let j = M - 1; j < N + M - 1; j++) {
+      const lockX = i - (M - 1)
+      const lockY = j - (M - 1)
+      aggregationGraph[i][j] = lock[lockX][lockY]
+    }
+  }
+  let rotatedKey = rotateKey(key)
+  for (let rotate = 0; rotate < 4; rotate++) {
+    //총 회전 네 번
+    for (let i = 0; i < N + M - 1; i++) {
+      for (let j = 0; j < N + M - 1; j++) {
+        //aggregationGraph 복사하여 사용하기
+        const copiedAggregationGraph = copyAggregationGraph(aggregationGraph)
+        //aggregationGraph상의 좌표인 i,j를 시작점으로 삼고,key의 값을 더하면서 채우기
+        for (let x = i; x < i + M; x++) {
+          for (let y = j; y < j + M; y++) {
+            const keyX = x - i
+            const keyY = y - j
+            copiedAggregationGraph[x][y] += rotatedKey[keyX][keyY]
+          }
+        }
+        // 합쳐진 copiedAggregationGraph 확인
+        // let str = ''
+        // copiedAggregationGraph.forEach((row) => {
+        //   str += row.join(' ') + '\n'
+        // })
+        // console.log(str)
+        //채우고 나서는 lock부분좌포들의 합이 모두 1인지 확인하기
+        let allOne = true
+        for (let i = M - 1; i < M - 1 + N; i++) {
+          for (let j = M - 1; j < M - 1 + N; j++) {
+            if (copiedAggregationGraph[i][j] !== 1) {
+              allOne = false
+              break
+            }
+          }
+        }
+        //만약 모두 1인 경우를 만족하면 열쇠가 자물쇠를 열 수 있는 경우임
+        if (allOne) answer = true
+      }
+    }
+    //키 회전시켜주기
+    rotatedKey = rotateKey(rotatedKey)
+  }
+
+  return answer
+}
+
+//테스트
+const key = [
+  [0, 0, 0],
+  [1, 0, 0],
+  [0, 1, 1],
+]
+const lock = [
+  [1, 1, 1],
+  [1, 1, 0],
+  [1, 0, 1],
+]
+console.log(solution(key, lock))


### PR DESCRIPTION
# 문제: [자물쇠와 열쇠](https://programmers.co.kr/learn/courses/30/lessons/60059)
## 문제풀이 접근법
- 완전탐색과 구현 문제로 접근했습니다.
제 문제해결 방식은 다음과 같습니다.
<img src=https://user-images.githubusercontent.com/44149596/163905882-cfb7b08a-d438-48f8-a93e-65d7d281288e.jpeg width="300"/>

- (1) key를 90도 회전
- (2) 회전한 key와 lock을 겹쳐서 각 겹치는 부분의 값의 합을 갱신합니다.
  - 그러면 "어떻게 겹칠것이냐?"를 구현하는 것이 핵심이 되겠네요. 저는 key의 크기와 lock의 크기를 고려한 새로운 테이블인 aggregationGraph를 만들어 사용했습니다.
<img src=https://user-images.githubusercontent.com/44149596/163905889-98d21700-dc67-4511-8de3-a89b008cddb7.jpeg width="300"/>
  - 위 그림은 제가 aggregationGraph를 생각해 낸 발상을 도식화 한 것입니다. key와 lock이 겹쳐지는 모습을 살펴보니, 아래와 같은 범위가 형성이 되었습니다. 그리고 그 범위를 별도의 테이블인 aggregationGraph로 만들어서 key와 lock을 합쳤습니다.

<img src=https://user-images.githubusercontent.com/44149596/163905895-9a05cc88-2d04-421c-a852-f3f583590e81.jpeg width="300"/>


- (3) lock이 있던 부분의 값들이 모두 1이라면 알맞게 열쇠게 들어맞은 경우이기 때문에, true처리를 해 줍니다.
## 구현 시 어려웠던 점과 깨달음
- 열쇠를 90도 회전하는 것이 어려웠습니다. row 좌표와 column 좌표를 적절히 계산하여 90도 회전토록 하는 것이 생소했습니다. 앞으로 좌표회전문제가 나오면 좀 더 능숙하게 풀 수 있을 것 같습니다.
- key 와 lock을 겹치기 위해서 새로운 테이블을 작성해야한다는 발상이 쉽지 않았고, 겹치는 로직에서 key와 lock, 그리고 aggregationGraph의 좌표값을 헷갈리지 않게 계산하는 것이 어려웠습니다.

