### PR TITLE
Add: 2022-05-02 튜플 문제해결

### DIFF
--- a/문자열/PG_튜플.js
+++ b/문자열/PG_튜플.js
@@ -1,0 +1,41 @@
+https://programmers.co.kr/learn/courses/30/lessons/64065
+const parser = (s) =>{
+  const showMap = {}
+  let tempStr =''
+  let isOpen= false
+  for(const c of s){
+      if(c==='{'){
+          isOpen = true
+      }
+      else if(c==='}'){
+          isOpen=false
+          const num = Number(tempStr)
+          if(num in showMap){
+              showMap[num].showCount++
+          }else{
+              showMap[num] = {number:num, showCount : 1}
+          }
+          tempStr=''
+      }else if(c===','){
+          if(isOpen){
+              const num = Number(tempStr)
+              if(num in showMap){
+                  showMap[num].showCount++
+              }else{
+                  showMap[num] = {number:num, showCount : 1}
+              }
+          }
+          tempStr=''
+      }else{
+        tempStr+=c   
+      }
+  }
+  const parsed = Object.values(showMap)
+  parsed.sort((a,b)=>b.showCount-a.showCount)
+  return parsed
+}
+
+function solution(s) {
+  const answer = parser(s.slice(1,s.length-1)).map(e=>e.number)
+  return answer;
+}


### PR DESCRIPTION
# 문제: [튜플](https://programmers.co.kr/learn/courses/30/lessons/64065)
## 문제풀이 접근법
- 주어진 입력값을 살펴보았을 때, n-튜플에서 등장하는 원소는 겹치지 않습니다. 또한, 원래 튜플의 앞 인덱스에 등장하는 원소부터 누적하여 n-튜플이 생성되므로, 
- 원래 튜플에서 앞에 존재하는 원소일수록, n-튜플에서 등장하는 횟수가 많습니다.
- 가령, {{1}.{3,2,1},{2,1}} 의 n- 튜플을 살펴보면, 1은 3번, 2는 2번, 3은 1번 등장합니다. 따라서 원래 튜플은 {1,2,3} 이었음을 확인할 수 있습니다.
- 이 점에 착안하여, 문자열을 parse 하면서 숫자를 구하고, 숫자의 등장 횟수를 별도의 객체에 저장했습니다.  
## 구현 시 어려웠던 점과 깨달음
- 정규식을 이용하면 조금 더 parse 과정이 쉽습니다.


