### PR TITLE
Add: 2022-05-06 징검다리 건너기 2차 문제풀이 - 문제해결

### DIFF
--- a/동적계획법/PG_징검다리건너기/PG_징검다리건너기_1차 풀이.js
+++ b/동적계획법/PG_징검다리건너기/PG_징검다리건너기_1차 풀이.js
@@ -1,0 +1,39 @@
+function solution(stones, k) {
+  //가장 긴 증가하는 부분수열 nlog(n) 응용인듯?
+  var answer = 0
+  let isStop = false
+  let counter = 0
+  while (!isStop) {
+    const dp = Array.from({ length: stones.length }, () => ({ length: 0, index: -1 }))
+    for (let i = 0; i < stones.length; i++) {
+      if (stones[i] === 0) {
+        //갱신
+        if (i - 1 >= 0 && stones[i - 1] === 0) {
+          dp[i].length = dp[i - 1].length + 1
+          dp[i].index = i
+          if (dp[i].length === k) {
+            isStop = true
+            break
+          }
+        } else if (i - 1 >= 0 && stones[i - 1] !== 0) {
+          //연속이 끊긴 것
+          dp[i].length = dp[i - 1].length
+          dp[i].index = i
+        } else if (i === 0) {
+          dp[i].length = 1
+          dp[i].index = i
+        }
+      } else {
+        //유지
+        if (i - 1 >= 0) {
+          dp[i].length = dp[i - 1].length
+          dp[i].index = dp[i - 1].length
+        }
+      }
+      stones[i] === 0 ? '' : (stones[i] -= 1)
+    }
+    answer++
+  }
+  return answer
+}
+console.log(solution([2, 4, 5, 3, 2, 1, 4, 2, 5, 1], 3, 3))

--- a/동적계획법/PG_징검다리건너기/PG_징검다리건너기_2차 문제풀이.js
+++ b/동적계획법/PG_징검다리건너기/PG_징검다리건너기_2차 문제풀이.js
@@ -1,0 +1,27 @@
+function solution(stones, k) {
+  let answer = 0
+  //건너는 사람 수를 기준으로 이분탐색을 해보자
+  let left = 1
+  let right = 200000000
+  while (left <= right) {
+    const people = Math.floor((left + right) / 2)
+    let max = 0
+    let consecutiveZeros = 0
+    for (let i = 0; i < stones.length; i++) {
+      if (stones[i] - people <= 0) {
+        consecutiveZeros++
+      } else {
+        max = Math.max(max, consecutiveZeros)
+        consecutiveZeros = 0
+      }
+    }
+    max = Math.max(max, consecutiveZeros)
+    if (max < k) {
+      left = people + 1
+    } else {
+      answer = people
+      right = people - 1
+    }
+  }
+  return answer
+}

--- a/동적계획법/PG_징검다리건너기/PG_징검다리건너기_2차 문제풀이.js
+++ b/동적계획법/PG_징검다리건너기/PG_징검다리건너기_2차 문제풀이.js
@@ -1,22 +1,23 @@
 function solution(stones, k) {
   let answer = 0
-  //건너는 사람 수를 기준으로 이분탐색을 해보자
   let left = 1
+  // let right = [...stones].sort((a, b) => b - a)[0] 는 시간초과
   let right = 200000000
   while (left <= right) {
     const people = Math.floor((left + right) / 2)
-    let max = 0
     let consecutiveZeros = 0
     for (let i = 0; i < stones.length; i++) {
-      if (stones[i] - people <= 0) {
-        consecutiveZeros++
+      if (consecutiveZeros < k) {
+        if (stones[i] - people <= 0) {
+          consecutiveZeros++
+        } else {
+          consecutiveZeros = 0
+        }
       } else {
-        max = Math.max(max, consecutiveZeros)
-        consecutiveZeros = 0
+        break
       }
     }
-    max = Math.max(max, consecutiveZeros)
-    if (max < k) {
+    if (consecutiveZeros < k) {
       left = people + 1
     } else {
       answer = people


### PR DESCRIPTION
# 문제: [징검다리 건너기](https://programmers.co.kr/learn/courses/30/lessons/64062)
## 문제풀이 접근법
### 1차 문제풀이(실패)
- 처음에는 stones를 순회하며 각 징검다리의 값을 1씩 줄여가면서, 연속적인 0의 징검다리의 최대개수가 k보다 같아지는 지점을 찾았습니다. 하지만, 이 방법은 O(n^2)의 시간복잡도를 지닙니다.
-  stones의 배열크기와 징검다리가 지닐 수 있는 값인 200,000,000 을 고려해볼 때, 해당 알고리즘을 선택하는 것은 굉장히 비효율적인 선택이라 판단했습니다. 
- 그리하여 메모리를 좀 더 사용하고 시간복잡도를 줄일 수 있는 `DP`로 접근하려 했으나 이 또한 잘 풀리지 않았습니다. 
- i번째 징검다리를 건널 수 있는 사람의 수를 i-1~ i-k번째에 징검다리를 건널 수 있는 사람의 수와 비교해가며 최적의 값을 갱신해 갈 수 있다고 생각했으나, 접근법 자체가 잘못된 것 같아 이진탐색 풀이로 전환했습니다.

### 2차 문제풀이(성공)
- DP를 활용한 풀이가 잘 되지 않아, O(log(n))의 시간복잡도를 갖는 `이진탐색`의 방법을 이용하는 접근법을 떠올리게 되었습니다.
- 그렇다면 관건은 과연 '무엇을 이진탐색할것인가?' 입니다.
- 징검다리가 지닐 수 있는 값은 1~200,000,000으로 한정되어 있습니다. 그리고 징검다리의 원소가 지니는 값이 곧 해당 원소 돌다리를 건널 수 있는 `최대 사람의 수`를 의미합니다. 
- 임의의 징검다리를 건너는 사람을 m으로 가정하고, m명의 사람은 징검다리를 반드시 모두 건너는 것으로 상황을 가정해봅시다. 1차 문제풀이에서는 m에 해당하는 징검다리 건너는 사람의 수를 1부터 차례대로 늘리는 방법을 사용하여 비효율이 발생했습니다. 이 비효율을 줄이기 위해서는 이`징검다리 건너는 사람의 수`를 이진탐색의 대상으로 삼아야 할 것입니다.
- 그렇다면 이 문제에서 이진탐색 알고리즘 내부에서의 `mid`값은 징검다리를 건너는 사람의 수가 됩니다. 
- mid만큼의 사람이 모든 징검다리를 건넌 후의 `stones`의 모습은 각 원소값-mid가 되겠네요.
- stones의 원소들 중 0이하의 값을 지니는 연속적인 원소들의 최대 길이가 k를 만족하는 최대의 mid가 우리가 원하는 답이 되겠습니다.

## 구현 시 어려웠던 점과 깨달음
- 모든 알고리즘 문제가 그러하듯, 문제풀이의 발상이 가장 어려웠습니다.
- 또한 잘못된 접근으로 문제를 바라보았을 때, 빠른 시간 내에 잘못된 접근임을 알아차리고 다른 접근법을 모색하려는 기민한 태도를 기르는 것이 중요하지만, 이를 습관화하기가 쉽지 않습니다.
- "이 문제가 왜 이진탐색일까"가 아닌 "어떻게 좀 더 효율적으로 접근할 수 있을까"가 새로운 문제에 대한 해결능력을 기르는 태도라고 생각합니다.

## 재미있는 점
```javascript
let right = Math.max(...stones)
```
이분탐색 시, right의 초기값을 200,000,000으로 하는 것이 비효율적이라 생각하여, stones의 최대값을 right의 초기값으로하여 이분탐색을 수행하였더니, 정확성 테스트는 통과하였지만, 효율성테스트에서 모두 `런타임 에러`가 떴습니다.
![image](https://user-images.githubusercontent.com/44149596/167104396-5bba7d6f-8bb7-46c9-b3e8-ace7b629bad8.png)

MDN에서 해당 에러의 이유를 찾을 수 있었습니다.``` Math.max(...arr)```와 같은 스프레드 연산자를 이용한 최대값 구하기 표현식은 배열의 요소가 너무 많다면 잘못된 결과를 출력할 수 있는데, 그 이유는 Math.max()에 전달된 배열이 함수요소를 통과하기 때문이랍니다.
![image](https://user-images.githubusercontent.com/44149596/167104640-432fc170-4149-4c21-90c1-ed79251a0fff.png)
[MDN 링크 - Math.max()](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Math/max)

```javascript
let right = [...stones].sort((a, b) => b - a)[0]
```
이를 해결하기 위해 stones를 복사한 배열을 정렬하여 최대값을 구하였는데, 정확성 테스트는 통과하였지만, 효율성테스트에서 `시간초과`가 떴습니다. 
![image](https://user-images.githubusercontent.com/44149596/167104000-39c5be42-abe5-4b51-8da8-15e8e51289a4.png)
그 이유는 아무래도 sort매서드는 O(nlog(n))의 시간복잡도를 갖고 있는데, 최대 200,000의 길이를 가진 stones를 스프레드 문법으로 얕은 복사를 하려다보니 O(n)만큼의 시간이 걸려, 결국에는 O(n^2log(n))의 매우 비효율적인 로직이 되어버렸기 때문인 듯 합니다.

그렇다면 stones의 최대값으로 right를 한정하는 가장 효율적인 방법은 무엇일까요?
아무래도 저는 reduce를 사용한 계산이 아닌가 싶습니다. MDN에서도 아래와 같이 안내를 하고 있네요. 
![image](https://user-images.githubusercontent.com/44149596/167106076-13aefb9a-a097-46d2-b34d-fb9ef1651fe1.png)
그렇다면 저는 이렇게 로직을 작성하면 되겠네요.
```javascript
let right = stones.reduce((acc,current)=> Math.max(acc,current),-Infinity)
```
이렇게 코드를 수정하고 나서의 효율성 채점 결과는 다음과 같습니다.
![image](https://user-images.githubusercontent.com/44149596/167106364-f6851a9d-885c-43a3-a9e1-dc920fa83665.png)

right를 200,000,000으로 하여 이진탐색을 수행한 원래 코드의 효율성 채점 결과는 다음과 같습니다.
![image](https://user-images.githubusercontent.com/44149596/167106614-2630bc54-cc1b-4798-a5e9-bd9da2f75f2b.png)

어라...? 테스트 1번을 제외하고는 코드를 수정했을 때의 결과가 수정 전보다 더 안좋군요.
이제 그 이유를 한 번 생각해봅시다. 
최대값을 구하는 로직은 O(n)만큼의 수행시간을 요합니다. 그리고 그 최대값은 최대 200,000,000이 될 수 있죠.
만약 배열에 200,000,000이 하나라도 껴 있다면, 최대값을 구하는 로직은 쓸모가 없어집니다. 

사실 log<sub>2</sub>(200000000)= 27.575424759099. 정도이기에, stones의 최대값을 아무리 줄인다 한들, 최대 길이 200,000의 stones 원소를 순회하며 최대값을 구하는 데 드는 비용이 더 클 수밖에 없더군요. 최대값을 구하는 로직이 더 효율적이려면, 해당 비용이 log<sub>2</sub>(200000000)보다는 적어야 하겠고, 그러려면 stones의 길이가 많이 작아야겠네요.

재미있는 실험이었고, 본의아니게 Math.max()에 대해 좀 더 잘 알게 되었던 문제였습니다. 이진탐색은 덤으로요.

