### PR TITLE
Add: 2022-05-06 양궁대회 문제해결

### DIFF
--- a/완전탐색/PG_양궁대회.js
+++ b/완전탐색/PG_양궁대회.js
@@ -1,14 +1,12 @@
-const combinationDFS = (visited, index, depth, search, result, pool) => {
-  if (depth === search) {
-    result.push([...visited])
+const binaryDFS = (index, n, result, pool) => {
+  if (index === n) {
+    result.push([...pool])
     return
   }
-  for (let i = index; i < visited.length; i++) {
-    if (visited[i]) continue
-    visited[i] = 1
-    combinationDFS(visited, i + 1, depth + 1, search, result, pool)
-    visited[i] = 0
-  }
+  //선택하고
+  binaryDFS(index + 1, n, result, [...pool, 1])
+  //선택하지않고
+  binaryDFS(index + 1, n, result, [...pool, 0])
 }
 
 function solution(n, info) {
@@ -16,10 +14,7 @@ function solution(n, info) {
   const totalScore = info.reduce((acc, curr, i) => acc + (curr > 0 ? 10 - i : 0), 0)
   let lionScore = 0
   const combinations = []
-  const visited = new Array(11).fill(0)
-  for (let search = 1; search <= n; search++) {
-    combinationDFS(visited, 0, 0, search, combinations, [])
-  }
+  binaryDFS(0, 11, combinations, [])
   let maxDiff = 0
   combinations.forEach((combLion) => {
     //1인 점수는 라이언이 가져가야 할 점수. 가져갈 점수를 위해서 몇 개의 활이 필요한지 계산하고, 만약 점수차가 가장 큰 조합이라면 추가.

--- a/완전탐색/PG_양궁대회.js
+++ b/완전탐색/PG_양궁대회.js
@@ -1,0 +1,67 @@
+const combinationDFS = (visited, index, depth, search, result, pool) => {
+  if (depth === search) {
+    result.push([...visited])
+    return
+  }
+  for (let i = index; i < visited.length; i++) {
+    if (visited[i]) continue
+    visited[i] = 1
+    combinationDFS(visited, i + 1, depth + 1, search, result, pool)
+    visited[i] = 0
+  }
+}
+
+function solution(n, info) {
+  let answer = []
+  const totalScore = info.reduce((acc, curr, i) => acc + (curr > 0 ? 10 - i : 0), 0)
+  let lionScore = 0
+  const combinations = []
+  const visited = new Array(11).fill(0)
+  for (let search = 1; search <= n; search++) {
+    combinationDFS(visited, 0, 0, search, combinations, [])
+  }
+  let maxDiff = 0
+  combinations.forEach((combLion) => {
+    //1인 점수는 라이언이 가져가야 할 점수. 가져갈 점수를 위해서 몇 개의 활이 필요한지 계산하고, 만약 점수차가 가장 큰 조합이라면 추가.
+    let lionScore = 0
+    let arrows = 0
+    let apeachScore = totalScore
+    const arrowsArr = []
+    combLion.forEach((hit, i) => {
+      if (!hit) {
+        arrowsArr.push(0)
+        return
+      }
+      const score = 10 - i
+      let hitCost = info[i] + 1
+      if (i === 10) {
+        //10을 맞춘 경우에,만약 더 사용할 수 있는 화살이 남아있으면, 소진해주기
+        if (n - arrows > 0) {
+          hitCost = n - arrows
+        }
+      }
+      arrows += hitCost
+      lionScore += score
+      apeachScore = info[i] > 0 ? apeachScore - score : apeachScore
+      arrowsArr.push(hitCost)
+    })
+    if (arrows === n && lionScore > apeachScore && lionScore - apeachScore >= maxDiff) {
+      answer.push({ diff: lionScore - apeachScore, arr: arrowsArr })
+      maxDiff = Math.max(lionScore - apeachScore, maxDiff)
+    }
+  })
+  answer = answer.filter((e) => e.diff === maxDiff).map((e) => e.arr)
+  //작은 활을 더 많이 맞춘 쪽으로 정렬
+  answer.sort((a, b) => {
+    for (let i = 10; i >= 0; i--) {
+      if (b[i] - a[i] === 0) {
+        continue
+      }
+      if (b[i] - a[i] > 0) {
+        return 1
+      }
+      return -1
+    }
+  })
+  return answer.length ? answer[0] : [-1]
+}


### PR DESCRIPTION
# 문제: [양궁대회](https://programmers.co.kr/learn/courses/30/lessons/92342)
## 문제풀이 접근법
- 문제의 핵심 달성 과제는 "어떻게 라이언과 어피치의 점수차이를 최대화 할 것인가"입니다.
- 처음에는 어떻게 문제를 풀어야 할 지 감조차 잡히지 않았습니다. 감을 잡기위해 문제를 여러 번 읽으면서 힌트를 찾았습니다.
- 라이언은 어피치의 점수를 뺏어오는 선택을 할 수도 있지만, 어피치가 맞추지 않은 활을 선택하는 선택을 함으로써 점수를 얻을 수도 있고, 그러한 선택들이 최적의 값을 도출할 수도 "있겠다"라는 생각을 했습니다. 
- 위 생각의 핵심은 반드시 어피치가 활을 쏜 곳만을 타겟으로 삼지 않고, 과녁의 모든 곳을 선택지로 두어야 한다는 것이었습니다. 
- 그렇다면 완전탐색(노가다)라는 키워드가 스멀스멀 떠오르게됩니다.
- 이렇게되면 결국 라이언이 획득하고자 하는 과녁의 점수의 가능한 모든 조합을 구해보고, 해당 조합을 만족시키기 위해 필요한 활의 개수가 n인지 확인하는 작업이 필연적이라 생각했습니다.
- 여기까지 생각이 도달하니, 구현과제는 크게 두 가지였습니다.
  - 과녁에서 라이언이 점수를 얻을 영역의 조합을 모두 도출
    - 모든 조합을 구하는 것이었기 때문에, nCr로직을 사용하지 않는 편이 더 좋았습니다. 문제를 맞춘 이후에, 이 부분은 이진DFS를 통해서 모든 경우의 수를 구하는 로직으로 수정하였습니다.
  - 조합을 검증 
    - 라이언이 얻을 점수를 이미 어피치가 얻었다면, 라이언이 이를 뺏어오기 위해서는 어피치가 소비한 활보다 +1 만큼 더 쏴야합니다. 
    - 만약 라이언이 어피치의 점수를 뺏어왔다면, 라이언의 점수는 증가시켜주어야하고, 어피치의 점수는 감소시켜주어야 합니다.
    - 만약 라이언이 0점 과녁영역을 선택했다면, 이 부분만은 어피치가 몇 개의 화살을 사용했든 상관없이, 라이언의 총 소비 화살이 n개가 되도록 남은 화살을 0점과녁에 소비해주면됩니다.
    - 이렇게 하여 도출된 라이언의 점수와 어피치의 점수차를 최대로 하는 조합을 조건에 맞게 정렬 후 답으로 삼으면 문제가 해결되었습니다. 
## 구현 시 어려웠던 점과 깨달음
- 완전탐색은 선뜻 선택하기가 망설여지는 문제 풀이 방법입니다. 무언가 더 효율적인 방법이 있지는 않을까? 하는 의심이 완전탐색을 과감하게 실행하기 어렵게 만듭니다. 사실은 별 것 아닌데 말이죠. 이제 저는 조합 알고리즘을 자유자재로 구현하여 사용할 수 있으니, 좀 더 과감해져도 될 것 같습니다.

