### PR TITLE
add: 2022-05-13 파괴되지 않은 건물 문제해결

### DIFF
--- a/수학/PG_파괴되지 않은 건물.js
+++ b/수학/PG_파괴되지 않은 건물.js
@@ -1,0 +1,35 @@
+function solution(board, skill) {
+  let answer = 0
+  const N = board.length
+  const M = board[0].length
+  const accBoard = Array.from({ length: N + 1 }, () => Array.from({ length: M + 1 }, () => 0))
+  skill.forEach((eachSkill) => {
+    let [type, r1, c1, r2, c2, degree] = eachSkill
+    if (type === 1) {
+      degree *= -1
+    }
+    accBoard[r1][c1] += degree
+    accBoard[r2 + 1][c1] += -1 * degree
+    accBoard[r1][c2 + 1] += -1 * degree
+    accBoard[r2 + 1][c2 + 1] += degree
+  })
+  //가로로누적합
+  for (let row = 0; row < N + 1; row++) {
+    for (let col = 1; col < M + 1; col++) {
+      accBoard[row][col] += accBoard[row][col - 1]
+    }
+  }
+  //세로로누적합
+  for (let col = 0; col < M + 1; col++) {
+    for (let row = 1; row < N + 1; row++) {
+      accBoard[row][col] += accBoard[row - 1][col]
+    }
+  }
+  //정답도출
+  for (let row = 0; row < N; row++) {
+    for (let col = 0; col < M; col++) {
+      board[row][col] + accBoard[row][col] > 0 ? answer++ : ''
+    }
+  }
+  return answer
+}


### PR DESCRIPTION
# 문제: [문제이름](https://www.acmicpc.net/problem/문제번호)
## 문제풀이 접근법
### 누적합을 이용하여 O(n^2)의 나이브한 배열 계산을 어떻게 O(1)로 변환하기

### 1차 문제풀이
1차 문제풀이에서는 단순한 구현에 초점을 두어 O(n^2)의 풀이법을 이용하였다. 배열의 크기가 (n) x (m)이고, k 개의 인풋이 존재한다고 하면 아래 풀이의 시간 복잡도는 O((k) x (n) x (m))이 되겠다. 물론 입력의 크기가 크기 때문에, 정합성은 통과했지만 효율성은 통과하지 못하는 코드가 되었다. 
나는 이 문제풀이 방식 말고는 더 방법이 생각이 안나 카카오 테크 블로그의 해설을 살펴보았고, '누적합'의 개념을 알게 되었다. 
```javascript
function solution(board, skill) {
    var answer = 0;
    const N = board.length
    const M = board[0].length
    const skillResult = Array.from({length:N},()=>Array.from({length:M},()=>0))
    skill.forEach(eachSkill=>{
        let [type, r1,c1,r2,c2,degree] = eachSkill

        if(type===1){
           degree *= -1
        }
        for(let row = r1; row<=r2; row++){
            for(let col = c1; col<=c2; col++){
                skillResult[row][col] += degree
            }
        }
    })
    for(let row = 0; row < N; row++){
        for(let col = 0; col < M; col++){
            board[row][col] + skillResult[row][col] >=1 ? answer++ : ''
        }
    }

    return answer;
}

```

### 2차 문제풀이 - 누적합을 이용한 풀이
이 누적합을 구하는 방법은 `imos`법이라고 하여, 0으로 초기화된 새로운 배열에 구간의 시작점과 끝점을 둘러싸는 사각형에 증가율 표시를 해 놓고, 나중에 배열을 누적합하여 한 번에 누적값을 계산하는 방법이다. O(1)시간만에 누적 변화율을 체크할 수 있으며, 나중에 한 번에 NxM의 순회를 통해 배열을 갱신하니, 시간 복잡도는 O(K+ NxM)이 될 것이다. 

자세한 설명은 아래 참고 링크에서 확인할 수 있다.

[참고 링크1 - imos 법](https://nicotina04.tistory.com/163)
[참고 링크2 - 카카오 테크 블로그 문제해설](https://tech.kakao.com/2022/01/14/2022-kakao-recruitment-round-1/)
[참고 링크3- 누적합 문제를 효율적으로 풀 수 있는 imos 법 ](https://velog.io/@nkrang/%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-imos-%EB%B2%95)
## 구현 시 어려웠던 점과 깨달음
- imos 방법론을 몰랐다면 절대로 효율성 풀이를 통과할 수 없을 것이다. 이러한 방법론의 존재를 알게 되어 학습하게 되었다는 것이 이 문제에서 내가 얻을 수 있는 가장 큰 수확이었다.
- 직교 좌표계의 N차원 배열에서 구간합을 구할 때, 또는 구간 값에 변동을 줄 때 imos 법을 사용하면 훨씬 간단하고 빠르게 풀린다는 것을 깨달았다.


