### PR TITLE
feat: 서로소 union-find 알고리즘과 Kruskal 알고리즘

### DIFF
--- a/그래프/BOJ_1717_집합의표현.js
+++ b/그래프/BOJ_1717_집합의표현.js
@@ -1,0 +1,56 @@
+// union-find 개념문제
+
+const readline = require('readline')
+const rl = readline.createInterface({
+  input: process.stdin,
+  ouput: process.stdout,
+})
+
+const input = []
+const answer = []
+let n = 0
+let m = 0
+let count = 0
+
+const findParent = (parent, x) => {
+  if (parent[x] !== x) {
+    parent[x] = findParent(parent, parent[x])
+  }
+  return parent[x]
+}
+
+const unionParent = (parent, a, b) => {
+  const aRoot = findParent(parent, a)
+  const bRoot = findParent(parent, b)
+  if (aRoot > bRoot) {
+    parent[aRoot] = bRoot
+  } else {
+    parent[bRoot] = aRoot
+  }
+}
+
+const solution = () => {
+  const parent = Array.from({ length: n + 1 }, (_, i) => i)
+  input.forEach(([cmd, a, b]) => {
+    if (cmd === 0) {
+      unionParent(parent, a, b)
+    } else {
+      answer.push(findParent(parent, a) === findParent(parent, b) ? 'YES' : 'NO')
+    }
+  })
+  console.log(answer.join('\n'))
+}
+
+rl.on('line', (l) => {
+  if (count === 0) {
+    let nm = l.split(' ').map(Number)
+    n = nm[0]
+    m = nm[1]
+  } else {
+    input.push(l.split(' ').map(Number))
+  }
+  count++
+}).on('close', () => {
+  solution()
+  process.exit()
+})

--- a/그래프/BOJ_1922_네트워크연결.js
+++ b/그래프/BOJ_1922_네트워크연결.js
@@ -1,0 +1,39 @@
+//크루스칼 알고리즘 연습문제
+const input = require('fs')
+  .readFileSync(process.platform === 'linux' ? 'dev/stdin' : 'test/test.txt')
+  .toString()
+  .trim()
+  .split('\n')
+
+const findParent = (parent, x) => {
+  if (parent[x] !== x) {
+    parent[x] = findParent(parent, parent[x])
+  }
+  return parent[x]
+}
+
+const union = (parent, a, b) => {
+  const aRoot = findParent(parent, a)
+  const bRoot = findParent(parent, b)
+  aRoot < bRoot ? (parent[bRoot] = aRoot) : (parent[aRoot] = bRoot)
+}
+
+const hasCycle = (parent, a, b) => {
+  return findParent(parent, a) === findParent(parent, b)
+}
+
+let N = +input.shift()
+let M = +input.shift()
+let cost = 0
+
+const sorted = input.map((s) => s.split(' ').map(Number)).sort((a, b) => a[2] - b[2])
+const parent = Array.from({ length: N + 1 }, (_, i) => i)
+
+sorted.forEach(([a, b, dist]) => {
+  if (!hasCycle(parent, a, b)) {
+    union(parent, a, b)
+    cost += dist
+  }
+})
+
+console.log(cost)

--- a/그래프/개념_MST_Kruskal.js
+++ b/그래프/개념_MST_Kruskal.js
@@ -1,0 +1,52 @@
+let input = `6
+9
+1 2 5
+1 3 4
+2 3 2
+2 4 7
+3 4 6
+3 5 11
+4 5 3
+4 6 8
+5 6 8
+`
+
+input = input.trim().split('\n')
+
+const findParent = (parent, x) => {
+  if (parent[x] !== x) {
+    parent[x] = findParent(parent, parent[x])
+  }
+  return parent[x]
+}
+
+const union = (parent, a, b) => {
+  const aRoot = findParent(parent, a)
+  const bRoot = findParent(parent, b)
+  aRoot < bRoot ? (parent[bRoot] = aRoot) : (parent[aRoot] = bRoot)
+}
+
+const hasCycle = (parent, a, b) => {
+  return findParent(parent, a) === findParent(parent, b)
+}
+
+let N = +input.shift()
+let M = +input.shift()
+let cost = 0
+
+/** Step1 - 간선을 오름차순으로 정렬한다 */
+const sorted = input.map((s) => s.split(' ').map(Number)).sort((a, b) => a[2] - b[2])
+const parent = Array.from({ length: N + 1 }, (_, i) => i)
+
+/** Steop2 - 간선을 순서대로 순회하며, 사이클이 없는 간선을 합해준다. union-find를 활용하여
+ * 같은 root노드여부를 확인해준다.
+ * hasCycle함수에서 parent테이블을 자동으로 업데이트해주고 있다.
+ */
+sorted.forEach(([a, b, dist]) => {
+  if (!hasCycle(parent, a, b)) {
+    union(parent, a, b)
+    cost += dist
+  }
+})
+
+console.log(cost)

--- a/그래프/개념_서로소_union-find.js
+++ b/그래프/개념_서로소_union-find.js
@@ -35,3 +35,14 @@ for (let i = 1; i < nodes + 1; i++) {
 }
 
 console.log(parent)
+
+/** 무방향 그래프에서의 사이클 판별 */
+
+let cycle = false
+for (const [node1, node2] of testEdges) {
+  if (findParent(parent, node1) === findParent(parent, node2)) {
+    cycle = true
+    break
+  }
+  unionParent(parent, node1, node2)
+}

--- a/그래프/개념_서로소_union-find.js
+++ b/그래프/개념_서로소_union-find.js
@@ -7,8 +7,10 @@ const testEdges = [
 ]
 
 const findParent = (parent, x) => {
-  if (parent[x] != x) return findParent(parent, parent[x])
-  return x
+  if (parent[x] != x) {
+    parent[x] = findParent(parent, parent[x])
+  }
+  return parent[x]
 }
 
 const unionParent = (parent, a, b) => {

--- a/그래프/개념_서로소_union-find.js
+++ b/그래프/개념_서로소_union-find.js
@@ -1,0 +1,35 @@
+const nodes = 6
+const testEdges = [
+  [1, 4],
+  [2, 3],
+  [2, 4],
+  [5, 6],
+]
+
+const findParent = (parent, x) => {
+  if (parent[x] != x) return findParent(parent, parent[x])
+  return x
+}
+
+const unionParent = (parent, a, b) => {
+  a = findParent(parent, a)
+  b = findParent(parent, b)
+  if (a < b) {
+    parent[b] = a
+  } else {
+    parent[a] = b
+  }
+}
+
+const parent = Array.from({ length: nodes + 1 }, (_, i) => i)
+
+for (const [node1, node2] of testEdges) {
+  unionParent(parent, node1, node2)
+}
+
+//각 원소가 속한 집합 출력 = 루트 노드를 찾으면 된다
+for (let i = 1; i < nodes + 1; i++) {
+  console.log(findParent(parent, i))
+}
+
+console.log(parent)


### PR DESCRIPTION
## 문제 유형
- union-find
- Kruskal

## 해당 문제 유형 풀이 포인트
- 특정 노드의 부모를 재귀적으로 찾아가는 행위를 통해서 노드가 `어떤 집합에 소속되어 있는지` 라는 `집합`의 개념을 구현함을 이해해야 한다.
- `동일한 집합에 루트 노드가 속해있다는 것`, 그것은 그래프에서 `사이클`을 이룬다는 것.

## 문제풀이 시 어려웠던 점과 깨달음
- 예전에는 사이클을 찾는 union-find 로직이 어려웠는데, 지금 보니 아무것도 아니었습니다. 
- 당시에는 왜 어려울까 생각을 해보았는데, 루트노드를 찾는다는 개념에서 `통상 노드 번호가 작은 쪽을 바라보게 parent 테이블을 업데이트하는` 행위를 제대로 인지하지 못하고 알고리즘을 접했기 때문이었습니다. 

